### PR TITLE
Several corrections related with multidimensional `FDataGrid` objects.

### DIFF
--- a/fda/validation.py
+++ b/fda/validation.py
@@ -3,8 +3,8 @@
 """
 import numpy
 
-import fda
 from fda import kernel_smoothers
+import fda
 
 
 __author__ = "Miguel Carbajo Berrocal"
@@ -142,7 +142,7 @@ def minimise(fdatagrid, parameters,
         >>> res['fdatagrid'].round(2)
         FDataGrid(
             array([[ 2.5 ,  1.67,  0.67,  1.67,  2.5 ]])
-            ,sample_points=array([[-2., -1.,  0.,  1.,  2.]])
+            ,sample_points=[array([-2., -1.,  0.,  1.,  2.])]
             ,sample_range=array([[-2.,  2.]])
             ,...)
 
@@ -236,7 +236,7 @@ def fpe(s_matrix):
     Returns:
          float: Penalisation given by the finite prediction error.
     """
-    return (1 + s_matrix.diagonal().mean())/(1 - s_matrix.diagonal().mean())
+    return (1 + s_matrix.diagonal().mean()) / (1 - s_matrix.diagonal().mean())
 
 
 def shibata(s_matrix):


### PR DESCRIPTION
- Corrected creation of multidimensional `FDataGrid` objects with
different number of sample points in each dimension. As a result,
`sample_points` is now a list of arrays. The doctests have been changed
accordingly.
- Corrected multidimensional mean (using `keepdims`).
- Improved `__getitem__` to allow not to specify values for some
dimensions. The problem with keys that are not slices remains.
- Added checks in plot an scatter of the dimension of the image.
- Changed round to not rounding sample points by default (maybe with an
additional argument?).